### PR TITLE
file Poe's works as "Poe, Edgar Allan" instead of "Allan Poe, Edgar"

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -72,7 +72,7 @@
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Edgar_Allan_Poe_bibliography#Tales</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/edgar-allan-poe_short-fiction</meta>
 		<dc:creator id="author">Edgar Allan Poe</dc:creator>
-		<meta property="file-as" refines="#author">Allan Poe, Edgar</meta>
+		<meta property="file-as" refines="#author">Poe, Edgar Allan</meta>
 		<meta property="se:url.encyclopedia.wikipedia" refines="#author">https://en.wikipedia.org/wiki/Edgar_Allan_Poe</meta>
 		<meta property="se:url.authority.nacoaf" refines="#author">https://id.loc.gov/authorities/names/n79029745</meta>
 		<meta property="role" refines="#author" scheme="marc:relators">ann</meta>


### PR DESCRIPTION
This is a metadata edit, not a transcription edit, so it's not clear to me whether it should go upstream to Gutenberg or not.  I think all the ebook metadata is Standard Ebooks's work.