### PR TITLE
Revert ditto marks

### DIFF
--- a/src/epub/text/the-gold-bug.xhtml
+++ b/src/epub/text/the-gold-bug.xhtml
@@ -228,79 +228,79 @@
 					<tr>
 						<td/>
 						<td>;</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>26.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>4</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>19.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>‡)</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>16.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>*</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>13.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>5</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>12.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>6</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>11.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>†1</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>8.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>0</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>6.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>92</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>5.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>:3</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>4.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>?</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>3.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>¶</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>2.</td>
 					</tr>
 					<tr>
 						<td/>
 						<td>—.</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>1.</td>
 					</tr>
 				</tbody>
@@ -363,52 +363,52 @@
 					</tr>
 					<tr>
 						<td>†</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>d</td>
 					</tr>
 					<tr>
 						<td>8</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>e</td>
 					</tr>
 					<tr>
 						<td>3</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>g</td>
 					</tr>
 					<tr>
 						<td>4</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>h</td>
 					</tr>
 					<tr>
 						<td>6</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>i</td>
 					</tr>
 					<tr>
 						<td>*</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>n</td>
 					</tr>
 					<tr>
 						<td>‡</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>o</td>
 					</tr>
 					<tr>
 						<td>(</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>r</td>
 					</tr>
 					<tr>
 						<td>;</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>t</td>
 					</tr>
 					<tr>
 						<td>?</td>
-						<td>〃</td>
+						<td>’’</td>
 						<td>u</td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
Wikipedia:

> The mark is made using ‘a pair of apostrophes’;<sup>[1]</sup> ‘a pair of marks " used underneath a word’;<sup>[3]</sup> the symbol " (quotation mark);<sup>[2][4]</sup> or the symbol ” (right double quotation mark).<sup>[5]</sup>

Notably missing from that description is U+3003 〃. In fact, U+3003 is part of Unicode’s [CJK Symbols and Punctuation block](https://unicode.org/charts/PDF/U3000.pdf). This is why it looks far too big in English text—it’s sized to fit in with ｆｕｌｌｗｉｄｔｈ　ｌｅｔｔｅｒｓ and Han characters. It’s also double‐width in a terminal.

I replaced it with two rsquo (`’’`), although I’m not sure whether it makes any real difference to just use rdquo (`”`).